### PR TITLE
Fixed some incompatible size_t -> int casts.

### DIFF
--- a/waved/utils.d
+++ b/waved/utils.d
@@ -24,7 +24,7 @@ struct Sound
     /// Returns: Length in number of frames.
     int lengthInFrames() pure const nothrow
     {
-        return data.length / numChannels;
+        return cast(int)(data.length) / numChannels;
     }
 
     /// Returns: Length in seconds.
@@ -202,10 +202,10 @@ void getRIFFChunkHeader(R)(ref R input, out uint chunkId, out uint chunkSize) if
 }
 
 // Writes RIFF chunk header (you have to count size manually for now...).
-void writeRIFFChunkHeader(R)(ref R output, uint chunkId, uint chunkSize) if (isOutputRange!(R, ubyte))
+void writeRIFFChunkHeader(R)(ref R output, uint chunkId, size_t chunkSize) if (isOutputRange!(R, ubyte))
 {
-    writeBE!uint(output, chunkId);
-    writeLE!uint(output, chunkSize);
+    writeBE!uint(output, cast(uint)(chunkId));
+    writeLE!uint(output, cast(uint)(chunkSize));
 }
 
 template RIFFChunkId(string id)

--- a/waved/wav.d
+++ b/waved/wav.d
@@ -221,10 +221,10 @@ void encodeWAV(R)(ref R output, Sound sound) if (isOutputRange!(R, ubyte))
     output.writeLE!ushort(cast(ushort)(sound.numChannels));
     output.writeLE!uint(cast(ushort)(sound.sampleRate));
 
-    uint bytesPerSec = sound.sampleRate * sound.numChannels * float.sizeof;
-    output.writeLE!uint(bytesPerSec);
+    size_t bytesPerSec = sound.sampleRate * sound.numChannels * float.sizeof;
+    output.writeLE!uint( cast(uint)(bytesPerSec));
 
-    int bytesPerFrame = sound.numChannels * float.sizeof;
+    int bytesPerFrame = cast(int)(sound.numChannels * float.sizeof);
     output.writeLE!ushort(cast(ushort)bytesPerFrame);
 
     output.writeLE!ushort(32);


### PR DESCRIPTION
At least on OSX 10.9, size_t is ulong and is not convertible to uint or int.

Tested with DMD 2.066 & LDC2 0.15.0-alpha1 (DMD v2.066.1, LLVM 3.5.0)
